### PR TITLE
support both esp32 and esp32s3

### DIFF
--- a/src/lib/mrubyc/hal.c
+++ b/src/lib/mrubyc/hal.c
@@ -46,8 +46,9 @@ static portMUX_TYPE mux = portMUX_INITIALIZER_UNLOCKED;
 
 */
 static void on_timer(void *arg) {
-  TIMERG0.int_clr_timers.t0_int_clr = 1;
-  TIMERG0.hw_timer[TIMER_0].config.tx_alarm_en = TIMER_ALARM_EN;
+  timer_group_clr_intr_status_in_isr(TIMER_GROUP_0, TIMER_0);
+  timer_group_enable_alarm_in_isr(TIMER_GROUP_0, TIMER_0);
+
   mrbc_tick();
 }
 

--- a/src/lib/mrubyc/hal.c
+++ b/src/lib/mrubyc/hal.c
@@ -16,7 +16,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "driver/periph_ctrl.h"
+//#include "driver/periph_ctrl.h"
 #include "driver/timer.h"
 #include "esp_types.h"
 #include "freertos/FreeRTOS.h"


### PR DESCRIPTION
The current code only supports esp32 (cannot build for esp32s3). This pull requiest makes both supported.
It is available for now but esp-idf shows deprecated warnings at compiling. Perhaps it needs more modification.

~/.platformio/packages/framework-espidf/components/driver/deprecated/driver/timer.h:16:2: warning: #warning "legacy timer group driver is deprecated, please migrate to driver/gptimer.h" [-Wcpp]
   16 | #warning "legacy timer group driver is deprecated, please migrate to driver/gptimer.h"
      |  ^~~~~~~