### PR TITLE
Common parts separated to default environment  in platformio.ini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -8,9 +8,12 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-[env:m5stack-stamps3]
+
+[platformio]
+; default_envs = m5stack-stamps3
+
+[env]
 platform = espressif32@6.10.0
-board = m5stack-stamps3
 framework = espidf
 lib_deps = 
 	m5stack/M5Unified@0.2.3
@@ -23,18 +26,9 @@ build_flags =
 	-DMAX_VM_COUNT=5
 	-DMRBC_INT64=1
 
+[env:m5stack-stamps3]
+board = m5stack-stamps3
+
 [env:m5stack-atom]
-platform = espressif32@6.10.0
 board = m5stack-atom
-framework = espidf
-lib_deps =
-    m5stack/M5Unified@0.2.3
-    https://github.com/mrubyc/mrubyc.git#2cbbbf757bbc9366fd319dd76753dc2c8b8386b9
-build_flags =
-    -Isrc/lib/mrubyc
-    -I.pio/libdeps/m5stack-atom/mrubyc/src
-    -Dhal_init=mrbchal_init
-    -DMRBC_SCHEDULER_EXIT=1
-    -DMAX_VM_COUNT=5
-    -DMRBC_INT64=1
 monitor_speed = 115200


### PR DESCRIPTION
Common parts in environments can commonize in platformio.ini. DRY.