### PR TITLE
imported m5unified classes partly  from mrubyc-m5

### DIFF
--- a/src/m5u/c_canvas.cpp
+++ b/src/m5u/c_canvas.cpp
@@ -1,0 +1,213 @@
+#include <M5Unified.h>
+
+#include "my_mrubydef.h"
+
+#ifdef USE_CANVAS
+#include "c_canvas.h"
+#include "drawing.h"
+
+static mrbc_class *canvas_class;
+
+static void c_canvas_new(mrb_vm *vm, mrb_value *v, int argc) {
+  v[0] = mrbc_instance_new(vm, v[0].cls, sizeof(M5Canvas));
+  mrbc_instance_call_initialize(vm, v, argc);
+}
+
+static void c_canvas_initialize(mrb_vm *vm, mrb_value *v, int argc) {
+  M5Canvas *canvas = new M5Canvas(&M5.Display);
+  *(M5Canvas **)v->instance->data = canvas;
+
+  if (argc > 2) {
+    int depth = val_to_i(vm, v, GET_ARG(3), argc);
+    canvas->setColorDepth(depth);
+  }
+  if (argc > 1) {
+    int width = val_to_i(vm, v, GET_ARG(1), argc);
+    int height = val_to_i(vm, v, GET_ARG(2), argc);
+    auto ptr = canvas->createSprite(width, height);
+    if (ptr == nullptr) {
+      delete canvas;
+      *(M5Canvas **)v->instance->data = nullptr;
+      mrbc_raise(vm, MRBC_CLASS(RuntimeError), "sprite creation failed");
+    }
+  } else {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "w/h");
+  }
+}
+
+static void c_canvas_create_sprite(mrb_vm *vm, mrb_value *v, int argc) {
+  M5Canvas *canvas = get_checked_data(M5Canvas, vm, v);
+  if (argc == 2) {
+    int width = val_to_i(vm, v, GET_ARG(1), argc);
+    int height = val_to_i(vm, v, GET_ARG(2), argc);
+    canvas->createSprite(width, height);
+  } else {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "width must be specified");
+    SET_FALSE_RETURN();
+  }
+}
+
+static void c_canvas_push_sprite(mrb_vm *vm, mrb_value *v, int argc) {
+  M5Canvas *canvas = get_checked_data(M5Canvas, vm, v);
+
+  if (argc == 2) {
+    int x = val_to_i(vm, v, GET_ARG(1), argc);
+    int y = val_to_i(vm, v, GET_ARG(2), argc);
+    canvas->pushSprite(x, y);
+  } else if (argc == 3) {
+    LovyanGFX *dst;
+    if (mrbc_obj_is_kind_of(&GET_ARG(1), canvas_class)) {
+      dst = get_checked_data(M5Canvas, vm, (&GET_ARG(1)));
+    } else {
+      dst = &M5.Display;  // no error, fall on default
+    }
+    int x = val_to_i(vm, v, GET_ARG(2), argc);
+    int y = val_to_i(vm, v, GET_ARG(3), argc);
+    canvas->pushSprite(dst, x, y);
+  } else {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "x-y");
+    SET_FALSE_RETURN();
+  }
+}
+
+static void c_canvas_delete_sprite(mrb_vm *vm, mrb_value *v, int argc) {
+  M5Canvas *canvas = get_checked_data(M5Canvas, vm, v);
+  canvas->deleteSprite();
+}
+
+static void c_canvas_scroll(mrb_vm *vm, mrb_value *v, int argc) {
+  M5Canvas *canvas = get_checked_data(M5Canvas, vm, v);
+  ;
+  draw_scroll(canvas, vm, v, argc);
+}
+
+static void c_canvas_get_dimension(mrb_vm *vm, mrb_value *v, int argc) {
+  M5Canvas *canvas = get_checked_data(M5Canvas, vm, v);
+  draw_get_dimension(canvas, vm, v, argc);
+}
+
+static void c_canvas_set_text_color(mrb_vm *vm, mrb_value *v, int argc) {
+  M5Canvas *canvas = get_checked_data(M5Canvas, vm, v);
+  draw_set_text_color(canvas, vm, v, argc);
+}
+
+static void c_canvas_set_text_size(mrb_vm *vm, mrb_value *v, int argc) {
+  M5Canvas *canvas = get_checked_data(M5Canvas, vm, v);
+  draw_set_text_size(canvas, vm, v, argc);
+}
+
+static void c_canvas_set_cursor(mrb_vm *vm, mrb_value *v, int argc) {
+  M5Canvas *canvas = get_checked_data(M5Canvas, vm, v);
+  draw_set_cursor(canvas, vm, v, argc);
+}
+
+static void c_canvas_get_cursor(mrb_vm *vm, mrb_value *v, int argc) {
+  M5Canvas *canvas = get_checked_data(M5Canvas, vm, v);
+  draw_get_cursor(canvas, vm, v, argc);
+}
+
+static void c_canvas_print(mrb_vm *vm, mrb_value *v, int argc) {
+  M5Canvas *canvas = get_checked_data(M5Canvas, vm, v);
+  draw_print(canvas, vm, v, argc);
+}
+
+static void c_canvas_puts(mrb_vm *vm, mrb_value *v, int argc) {
+  M5Canvas *canvas = get_checked_data(M5Canvas, vm, v);
+  draw_puts(canvas, vm, v, argc);
+}
+
+static void c_canvas_clear(mrb_vm *vm, mrb_value *v, int argc) {
+  M5Canvas *canvas = get_checked_data(M5Canvas, vm, v);
+  draw_clear(canvas, vm, v, argc);
+}
+
+static void class_canvas_fill_rect(mrb_vm *vm, mrb_value *v, int argc) {
+  M5Canvas *canvas = get_checked_data(M5Canvas, vm, v);
+  draw_fill_rect(canvas, vm, v, argc);
+}
+
+static void class_canvas_draw_rect(mrb_vm *vm, mrb_value *v, int argc) {
+  M5Canvas *canvas = get_checked_data(M5Canvas, vm, v);
+  draw_draw_rect(canvas, vm, v, argc);
+}
+
+static void class_canvas_flll_circle(mrb_vm *vm, mrb_value *v, int argc) {
+  M5Canvas *canvas = get_checked_data(M5Canvas, vm, v);
+  draw_flll_circle(canvas, vm, v, argc);
+}
+
+static void class_canvas_draw_circle(mrb_vm *vm, mrb_value *v, int argc) {
+  M5Canvas *canvas = get_checked_data(M5Canvas, vm, v);
+  draw_draw_circle(canvas, vm, v, argc);
+}
+
+static void class_canvas_draw_line(mrb_vm *vm, mrb_value *v, int argc) {
+  M5Canvas *canvas = get_checked_data(M5Canvas, vm, v);
+  draw_draw_line(canvas, vm, v, argc);
+}
+
+#ifdef USE_FILE_FUNCTION
+static void class_canvas_draw_bmp(mrb_vm *vm, mrb_value *v, int argc) {
+  M5Canvas *canvas = get_checked_data(M5Canvas, vm, v);
+  draw_draw_bmp(canvas, vm, v, argc);
+}
+
+static void class_canvas_draw_jpg(mrb_vm *vm, mrb_value *v, int argc) {
+  M5Canvas *canvas = get_checked_data(M5Canvas, vm, v);
+  draw_draw_jpg(canvas, vm, v, argc);
+}
+
+static void class_canvas_draw_png(mrb_vm *vm, mrb_value *v, int argc) {
+  M5Canvas *canvas = get_checked_data(M5Canvas, vm, v);
+  draw_draw_png(canvas, vm, v, argc);
+}
+
+#endif  // USE_FILE_FUNCTION
+
+static void class_canvas_set_rotation(mrb_vm *vm, mrb_value *v, int argc) {
+  M5Canvas *canvas = get_checked_data(M5Canvas, vm, v);
+  draw_set_rotation(canvas, vm, v, argc);
+}
+
+static void class_canvas_destroy(mrb_vm *vm, mrb_value *v, int argc) {
+  M5Canvas *canvas = get_checked_data(M5Canvas, vm, v);
+  delete canvas;
+  put_null_data(v);
+}
+
+void class_canvas_init() {
+  // define class
+  canvas_class = mrbc_define_class(0, "Canvas", mrbc_class_object);
+  mrbc_define_method(0, canvas_class, "new", c_canvas_new);
+  mrbc_define_method(0, canvas_class, "initialize", c_canvas_initialize);
+  mrbc_define_method(0, canvas_class, "scroll", c_canvas_scroll);
+  mrbc_define_method(0, canvas_class, "push_sprite", c_canvas_push_sprite);
+  mrbc_define_method(0, canvas_class, "delete_sprite", c_canvas_delete_sprite);
+  mrbc_define_method(0, canvas_class, "create_sprite", c_canvas_create_sprite);
+  mrbc_define_method(0, canvas_class, "destroy", class_canvas_destroy);
+
+  mrbc_define_method(0, canvas_class, "set_text_color",
+                     c_canvas_set_text_color);
+  mrbc_define_method(0, canvas_class, "set_text_size", c_canvas_set_text_size);
+  mrbc_define_method(0, canvas_class, "set_cursor", c_canvas_set_cursor);
+  mrbc_define_method(0, canvas_class, "get_cursor", c_canvas_get_cursor);
+  mrbc_define_method(0, canvas_class, "print", c_canvas_print);
+  mrbc_define_method(0, canvas_class, "puts", c_canvas_puts);
+  mrbc_define_method(0, canvas_class, "clear", c_canvas_clear);
+
+  mrbc_define_method(0, canvas_class, "fill_rect", class_canvas_fill_rect);
+  mrbc_define_method(0, canvas_class, "draw_rect", class_canvas_draw_rect);
+  mrbc_define_method(0, canvas_class, "fill_circle", class_canvas_flll_circle);
+  mrbc_define_method(0, canvas_class, "draw_circle", class_canvas_draw_circle);
+  mrbc_define_method(0, canvas_class, "draw_line", class_canvas_draw_line);
+#ifdef USE_FILE_FUNCTION
+  mrbc_define_method(0, canvas_class, "draw_bmpfile", class_canvas_draw_bmp);
+  mrbc_define_method(0, canvas_class, "draw_jpgfile", class_canvas_draw_jpg);
+  mrbc_define_method(0, canvas_class, "draw_pngfile", class_canvas_draw_png);
+#endif  // USE_FILE_FUNCTION
+  mrbc_define_method(0, canvas_class, "set_rotation",
+                     class_canvas_set_rotation);
+  mrbc_define_method(0, canvas_class, "dimension", c_canvas_get_dimension);
+}
+
+#endif  // USE_CANVAS

--- a/src/m5u/c_canvas.h
+++ b/src/m5u/c_canvas.h
@@ -1,0 +1,3 @@
+extern "C" {
+    void class_canvas_init();
+}

--- a/src/m5u/c_display_button.cpp
+++ b/src/m5u/c_display_button.cpp
@@ -1,0 +1,213 @@
+#include "c_display_button.h"
+
+#include <M5Unified.h>
+
+#include "drawing.h"
+#include "my_mrubydef.h"
+
+static void class_display_color_value(mrb_vm *vm, mrb_value *v, int argc) {
+  if (argc > 2) {
+    uint8_t r = val_to_i(vm, v, GET_ARG(1), argc);
+    uint8_t g = val_to_i(vm, v, GET_ARG(2), argc);
+    uint8_t b = val_to_i(vm, v, GET_ARG(3), argc);
+    uint16_t color = ((r >> 3) << 11) | ((g >> 2) << 5) | (b >> 3);
+    SET_INT_RETURN(color);
+  } else {
+    SET_FALSE_RETURN();
+  }
+}
+
+static void class_display_available(mrb_vm *vm, mrb_value *v, int argc) {
+  if (M5.getDisplayCount() > 0) {
+    SET_TRUE_RETURN();
+  } else {
+    SET_FALSE_RETURN();
+  }
+}
+
+static void class_display_dimension(mrb_vm *vm, mrb_value *v, int argc) {
+  draw_get_dimension(&M5.Display, vm, v, argc);
+}
+
+static void class_display_set_text_size(mrb_vm *vm, mrb_value *v, int argc) {
+  draw_set_text_size(&M5.Display, vm, v, argc);
+}
+static void class_display_set_text_color(mrb_vm *vm, mrb_value *v, int argc) {
+  draw_set_text_color(&M5.Display, vm, v, argc);
+}
+static void class_display_print(mrb_vm *vm, mrb_value *v, int argc) {
+  draw_print(&M5.Display, vm, v, argc);
+}
+static void class_display_puts(mrb_vm *vm, mrb_value *v, int argc) {
+  draw_puts(&M5.Display, vm, v, argc);
+}
+static void class_display_clear(mrb_vm *vm, mrb_value *v, int argc) {
+  draw_clear(&M5.Display, vm, v, argc);
+}
+static void class_display_set_cursor(mrb_vm *vm, mrb_value *v, int argc) {
+  draw_set_cursor(&M5.Display, vm, v, argc);
+}
+static void class_display_get_cursor(mrb_vm *vm, mrb_value *v, int argc) {
+  draw_get_cursor(&M5.Display, vm, v, argc);
+}
+
+static void class_display_set_rotation(mrb_vm *vm, mrb_value *v, int argc) {
+  draw_set_rotation(&M5.Display, vm, v, argc);
+}
+
+#ifdef USE_DISPLAY_GRAPHICS
+
+static void class_display_fill_rect(mrb_vm *vm, mrb_value *v, int argc) {
+  draw_fill_rect(&M5.Display, vm, v, argc);
+}
+
+static void class_display_draw_rect(mrb_vm *vm, mrb_value *v, int argc) {
+  draw_draw_rect(&M5.Display, vm, v, argc);
+}
+
+static void class_display_flll_circle(mrb_vm *vm, mrb_value *v, int argc) {
+  draw_flll_circle(&M5.Display, vm, v, argc);
+}
+
+static void class_display_draw_circle(mrb_vm *vm, mrb_value *v, int argc) {
+  draw_draw_circle(&M5.Display, vm, v, argc);
+}
+
+static void class_display_draw_line(mrb_vm *vm, mrb_value *v, int argc) {
+  draw_draw_line(&M5.Display, vm, v, argc);
+}
+
+#ifdef USE_FILE_FUNCTION
+static void class_display_draw_bmp(mrb_vm *vm, mrb_value *v, int argc) {
+  draw_draw_bmp(&M5.Display, vm, v, argc);
+}
+
+static void class_display_draw_jpg(mrb_vm *vm, mrb_value *v, int argc) {
+  draw_draw_jpg(&M5.Display, vm, v, argc);
+}
+
+static void class_display_draw_png(mrb_vm *vm, mrb_value *v, int argc) {
+  draw_draw_png(&M5.Display, vm, v, argc);
+}
+#endif  // USE_FILE_FUNCTION
+
+static void class_display_scroll(mrb_vm *vm, mrb_value *v, int argc) {
+  draw_scroll(&M5.Display, vm, v, argc);
+}
+
+static void class_display_wait_display(mrb_vm *vm, mrb_value *v, int argc) {
+  M5.Display.waitDisplay();
+}
+
+static void class_display_start_write(mrb_vm *vm, mrb_value *v, int argc) {
+  M5.Display.startWrite();
+}
+
+static void class_display_end_write(mrb_vm *vm, mrb_value *v, int argc) {
+  M5.Display.endWrite();
+}
+
+#endif  // USE_DISPLAY_GRAPHICS
+
+static void class_btn_is_pressed(mrb_vm *vm, mrb_value *v, int argc) {
+  int no = *v->instance->data;
+  m5::Button_Class btns[] = {M5.BtnA, M5.BtnB, M5.BtnC,
+#ifdef USE_FULL_BUTTONS
+                             M5.BtnEXT, M5.BtnPWR
+#endif
+  };
+  if (0 <= no && no < sizeof(btns)) {
+    if (btns[no].isPressed()) {
+      SET_TRUE_RETURN();
+    } else {
+      SET_FALSE_RETURN();
+    }
+  }
+}
+
+static void class_btn_was_pressed(mrb_vm *vm, mrb_value *v, int argc) {
+  int no = *v->instance->data;
+  m5::Button_Class btns[] = {M5.BtnA, M5.BtnB, M5.BtnC};
+  if (0 <= no && no < sizeof(btns)) {
+    if (btns[no].wasPressed()) {
+      SET_TRUE_RETURN();
+    } else {
+      SET_FALSE_RETURN();
+    }
+  }
+}
+
+static void class_btn_no(mrb_vm *vm, mrb_value *v, int argc) {
+  SET_INT_RETURN(*v->instance->data);
+}
+
+void class_display_button_init() {
+  mrb_class *class_display;
+  class_display = mrbc_define_class(0, "Display", mrbc_class_object);
+  mrbc_define_method(0, class_display, "available?", class_display_available);
+
+  mrbc_define_method(0, class_display, "print", class_display_print);
+  mrbc_define_method(0, class_display, "println", class_display_puts);
+  mrbc_define_method(0, class_display, "puts", class_display_puts);
+  mrbc_define_method(0, class_display, "set_text_size",
+                     class_display_set_text_size);
+  mrbc_define_method(0, class_display, "set_text_color",
+                     class_display_set_text_color);
+  mrbc_define_method(0, class_display, "clear", class_display_clear);
+  mrbc_define_method(0, class_display, "set_cursor", class_display_set_cursor);
+  mrbc_define_method(0, class_display, "get_cursor", class_display_get_cursor);
+
+  mrbc_define_method(0, class_display, "color565", class_display_color_value);
+  mrbc_define_method(0, class_display, "dimension", class_display_dimension);
+
+#ifdef USE_DISPLAY_GRAPHICS
+  mrbc_define_method(0, class_display, "start_write",
+                     class_display_start_write);
+  mrbc_define_method(0, class_display, "end_write", class_display_end_write);
+  mrbc_define_method(0, class_display, "fill_rect", class_display_fill_rect);
+  mrbc_define_method(0, class_display, "draw_rect", class_display_draw_rect);
+  mrbc_define_method(0, class_display, "fill_circle",
+                     class_display_flll_circle);
+  mrbc_define_method(0, class_display, "draw_circle",
+                     class_display_draw_circle);
+  mrbc_define_method(0, class_display, "draw_line", class_display_draw_line);
+#ifdef USE_FILE_FUNCTION
+  mrbc_define_method(0, class_display, "draw_bmpfile", class_display_draw_bmp);
+  mrbc_define_method(0, class_display, "draw_jpgfile", class_display_draw_jpg);
+  mrbc_define_method(0, class_display, "draw_pngfile", class_display_draw_png);
+#endif  // USE_FILE_FUNCTION
+  mrbc_define_method(0, class_display, "wait_display",
+                     class_display_wait_display);
+  mrbc_define_method(0, class_display, "scroll", class_display_scroll);
+  mrbc_define_method(0, class_display, "set_rotation",
+                     class_display_set_rotation);
+#endif  // USE_DISPLAY_GRAPHICS
+
+  mrb_class *class_btn, *class_btna, *class_btnb, *class_btnc;
+  class_btn = mrbc_define_class(0, "BtnClass", mrbc_class_object);
+  mrbc_define_method(0, class_btn, "is_pressed?", class_btn_is_pressed);
+  mrbc_define_method(0, class_btn, "was_pressed?", class_btn_was_pressed);
+  mrbc_define_method(0, class_btn, "number", class_btn_no);
+
+  mrbc_value btn = mrbc_instance_new(0, class_btn, sizeof(int));
+  *btn.instance->data = 0;  // btnA
+  mrbc_set_const(mrbc_str_to_symid("BtnA"), &btn);
+
+  btn = mrbc_instance_new(0, class_btn, sizeof(int));
+  *btn.instance->data = 1;  // btnB
+  mrbc_set_const(mrbc_str_to_symid("BtnB"), &btn);
+
+  btn = mrbc_instance_new(0, class_btn, sizeof(int));
+  *btn.instance->data = 2;  // btnC
+  mrbc_set_const(mrbc_str_to_symid("BtnC"), &btn);
+
+#ifdef USE_FULL_BUTTONS
+  btn = mrbc_instance_new(0, class_btn, sizeof(int));
+  *btn.instance->data = 3;  // btnEXT
+  mrbc_set_const(mrbc_str_to_symid("BtnEXT"), &btn);
+
+  btn = mrbc_instance_new(0, class_btn, sizeof(int));
+  *btn.instance->data = 4;  // btnPWR
+  mrbc_set_const(mrbc_str_to_symid("BtnPWR"), &btn);
+#endif  // USE_ FULL_BUTTONS
+}

--- a/src/m5u/c_display_button.h
+++ b/src/m5u/c_display_button.h
@@ -1,0 +1,3 @@
+extern "C" {
+    void class_display_button_init();
+}

--- a/src/m5u/c_m5.cpp
+++ b/src/m5u/c_m5.cpp
@@ -1,0 +1,43 @@
+
+#include <M5Unified.h>
+
+#include "my_mrubydef.h"
+
+static void class_m5_update(mrb_vm *vm, mrb_value *v, int argc) { M5.update(); }
+
+static void  // see definition of "enum board_t" in M5GFX/src/lgfx/boards.hpp
+class_m5_board(mrb_vm *vm, mrb_value *v, int argc) {
+  SET_INT_RETURN(M5.getBoard());
+}
+
+#define VER_N_STR(n) VER_N_STR_H(n)
+#define VER_N_STR_H(n) #n
+static void class_m5_version(mrb_vm *vm, mrb_value *v,
+                             int argc) {  // a little small challenge
+  SET_RETURN(mrbc_string_new_cstr(
+      vm, VER_N_STR(M5UNIFIED_VERSION_MAJOR) "." VER_N_STR(
+              M5UNIFIED_VERSION_MINOR) "." VER_N_STR(M5UNIFIED_VERSION_PATCH)));
+
+  //    char buf[32];
+  //    snprintf(buf, sizeof(buf), "%d.%d.%d", M5UNIFIED_VERSION_MAJOR,
+  //    M5UNIFIED_VERSION_MINOR, M5UNIFIED_VERSION_PATCH);
+  //    SET_RETURN(mrbc_string_new_cstr(vm, buf));
+}
+
+mrbc_value failed_object;
+
+void false_return(mrb_vm *vm, mrb_value *v, int argc) { SET_FALSE_RETURN(); }
+void true_return(mrb_vm *vm, mrb_value *v, int argc) { SET_TRUE_RETURN(); }
+
+void class_m5_init() {
+  mrb_class *class_m5;
+  class_m5 = mrbc_define_class(0, "M5", mrbc_class_object);
+  mrbc_define_method(0, class_m5, "update", class_m5_update);
+  mrbc_define_method(0, class_m5, "board", class_m5_board);
+  mrbc_define_method(0, class_m5, "unified_version", class_m5_version);
+
+  mrb_class *class_failed =
+      mrbc_define_class(0, "FailObject", mrbc_class_object);
+  mrbc_define_method(0, class_failed, "method_missing", false_return);
+  failed_object = mrbc_instance_new(0, class_failed, 0);
+}

--- a/src/m5u/c_m5.h
+++ b/src/m5u/c_m5.h
@@ -1,0 +1,9 @@
+#include "mrubyc.h"
+
+extern "C" {
+    extern mrbc_value failed_object;
+    void false_return(mrb_vm *vm, mrb_value *v, int argc);
+    void true_return(mrb_vm *vm, mrb_value *v, int argc);
+    void class_m5_init();
+    void my_mrubyc_init();
+}

--- a/src/m5u/c_m5u.cpp
+++ b/src/m5u/c_m5u.cpp
@@ -1,0 +1,20 @@
+#include "c_m5u.h"
+
+#include <M5Unified.h>
+
+#include "c_canvas.h"
+#include "c_display_button.h"
+#include "c_m5.h"
+#include "c_speaker.h"
+#include "c_touch.h"
+#include "c_utils.h"
+#include "mrubyc.h"
+
+void init_c_m5u() {
+  class_m5_init();
+  class_display_button_init();
+  class_utils_init();
+  class_touch_init();
+  class_canvas_init();
+  class_speaker_init();
+}

--- a/src/m5u/c_m5u.h
+++ b/src/m5u/c_m5u.h
@@ -1,0 +1,4 @@
+
+extern "C" {
+void init_c_m5u();
+}

--- a/src/m5u/c_speaker.cpp
+++ b/src/m5u/c_speaker.cpp
@@ -1,0 +1,67 @@
+#include <M5Unified.h>
+
+#include "my_mrubydef.h"
+#include "c_speaker.h"
+
+#ifdef USE_SPEAKER
+
+static void c_speaker_tone(mrb_vm *vm, mrb_value *v, int argc) {
+    if(argc<2){
+        mrbc_raise(vm, MRBC_CLASS(ArgumentError), "wrong number of arguments"); 
+        SET_FALSE_RETURN();
+        return;
+    }
+
+    int freq = val_to_f(vm, v, GET_ARG(1), argc);
+    int duration = val_to_i(vm, v, GET_ARG(2), argc);
+    int channel = (argc>2)? val_to_i(vm, v, GET_ARG(3), argc) : -1;
+    bool stop_current = (argc<4 || ( GET_ARG(4).tt != MRBC_TT_NIL && GET_ARG(4).tt!=MRBC_TT_FALSE ));
+    M5.Speaker.tone(freq, duration,channel, stop_current);
+}
+
+static void c_speaker_stop(mrb_vm *vm, mrb_value *v, int argc) {
+    if(argc>0) {
+        int channel = val_to_i(vm, v, GET_ARG(1), argc);
+        M5.Speaker.stop(channel);
+    } else {
+        M5.Speaker.stop();
+    }
+}
+
+static void c_speaker_set_volume(mrb_vm *vm, mrb_value *v, int argc) {
+    if(argc<1){
+        mrbc_raise(vm, MRBC_CLASS(ArgumentError), "wrong number of arguments"); 
+        SET_FALSE_RETURN();
+        return;
+    }
+
+    int volume = val_to_i(vm, v, GET_ARG(1), argc);
+    M5.Speaker.setVolume(volume);
+}
+
+static void c_speaker_get_volume(mrb_vm *vm, mrb_value *v, int argc) {
+    int volume = M5.Speaker.getVolume();
+    SET_INT_RETURN(volume);
+}
+
+static void c_speaker_is_playing(mrb_vm *vm, mrb_value *v, int argc) {
+    int channel = (argc>0)? val_to_i(vm, v, GET_ARG(1), argc) : -1;
+    if(M5.Speaker.isPlaying(channel)){
+        SET_TRUE_RETURN();
+    } else {
+        SET_FALSE_RETURN(); 
+    }
+}
+
+void class_speaker_init() {
+    mrbc_class *speaker = mrbc_define_class(0,"Speaker", mrbc_class_object);
+    mrbc_define_method(0, speaker, "tone", c_speaker_tone);
+    mrbc_define_method(0, speaker, "stop", c_speaker_stop);
+    mrbc_define_method(0, speaker, "set_volume", c_speaker_set_volume);
+    mrbc_define_method(0, speaker, "volume=", c_speaker_set_volume);
+    mrbc_define_method(0, speaker, "get_volume", c_speaker_get_volume);
+    mrbc_define_method(0, speaker, "volume", c_speaker_set_volume);
+    mrbc_define_method(0, speaker, "is_playing?", c_speaker_is_playing);
+}
+
+#endif // USE_SPEAKER

--- a/src/m5u/c_speaker.h
+++ b/src/m5u/c_speaker.h
@@ -1,0 +1,4 @@
+
+extern "C" {
+    void class_speaker_init();
+}

--- a/src/m5u/c_touch.cpp
+++ b/src/m5u/c_touch.cpp
@@ -1,0 +1,102 @@
+#include <M5Unified.h>
+#include "my_mrubydef.h"
+#include "c_touch.h"
+
+#ifdef USE_TOUCH
+
+static void
+class_touch_get_count(mrb_vm *vm, mrb_value *v, int argc)
+{
+    SET_INT_RETURN(M5.Touch.getCount());
+}
+
+static void
+class_touch_get_detail(mrb_vm *vm, mrb_value *v, int argc)
+{
+    int no = (argc>0)? GET_INT_ARG(1) : 0;
+    if(no<M5.Touch.getCount()){
+        auto detail = M5.Touch.getDetail(no);
+        mrb_value ret = mrbc_array_new(vm, 5);
+        mrb_value a[5];
+        a[0] = mrbc_integer_value(detail.x);
+        a[1] = mrbc_integer_value(detail.y);
+        a[2] = mrbc_integer_value(detail.prev_x);
+        a[3] = mrbc_integer_value(detail.prev_y);
+        a[4] = mrbc_integer_value(detail.id); 
+        mrbc_array_set(&ret, 0, &a[0]);
+        mrbc_array_set(&ret, 1, &a[1]);
+        mrbc_array_set(&ret, 2, &a[2]);
+        mrbc_array_set(&ret, 3, &a[3]);
+        mrbc_array_set(&ret, 4, &a[4]);
+        SET_RETURN(ret);
+        return;
+    }
+    SET_NIL_RETURN();
+}
+
+static void class_touch_wasclicked(mrb_vm *vm, mrb_value *v, int argc)
+{
+    int no = (argc>0)? val_to_i(vm,v,GET_ARG(1),argc) : 0;
+    if(no<M5.Touch.getCount()){
+        if(M5.Touch.getDetail(no).wasClicked()){  
+            SET_TRUE_RETURN();
+            return;
+        }
+    }
+    SET_FALSE_RETURN();
+}
+
+static void class_touch_ispressed(mrb_vm *vm, mrb_value *v, int argc)
+{
+    int no = (argc>0)? val_to_i(vm,v,GET_ARG(1),argc)  : 0;
+    if(no<M5.Touch.getCount()){
+        if(M5.Touch.getDetail(no).isPressed()){
+            SET_TRUE_RETURN();
+            return;
+        }
+    }
+    SET_FALSE_RETURN();
+}
+
+static void class_touch_isreleased(mrb_vm *vm, mrb_value *v, int argc)
+{
+    int no = (argc>0)?  val_to_i(vm,v,GET_ARG(1),argc)  : 0;
+    if(no<M5.Touch.getCount()){
+        if(M5.Touch.getDetail(no).isReleased()){
+            SET_TRUE_RETURN();
+            return;
+        }
+    }
+    SET_FALSE_RETURN();
+}
+
+static void class_touch_isholding(mrb_vm *vm, mrb_value *v, int argc)
+{
+    int no = (argc>0)?  val_to_i(vm,v,GET_ARG(1),argc)  : 0;
+    if(no<M5.Touch.getCount()){
+        if(M5.Touch.getDetail(no).isHolding()){
+            SET_TRUE_RETURN();
+            return;
+        }
+    }
+    SET_FALSE_RETURN();
+}
+
+
+void class_touch_init(){
+    if(M5.Touch.isEnabled()){
+        mrb_class *class_touch;
+        class_touch = mrbc_define_class(0, "Touch", mrbc_class_object);
+        mrbc_define_method(0, class_touch, "available?", true_return);
+        mrbc_define_method(0, class_touch, "count", class_touch_get_count);
+        mrbc_define_method(0, class_touch, "detail", class_touch_get_detail);
+        mrbc_define_method(0, class_touch, "was_clicked?", class_touch_wasclicked);
+        mrbc_define_method(0, class_touch, "is_pressed?", class_touch_ispressed);
+        mrbc_define_method(0, class_touch, "is_released?", class_touch_isreleased);
+        mrbc_define_method(0, class_touch, "is_holding?", class_touch_isholding);
+    } else {
+        mrbc_set_const(mrbc_str_to_symid("Touch"), &failed_object);
+    }
+}
+
+#endif // USE_TOUCH

--- a/src/m5u/c_touch.h
+++ b/src/m5u/c_touch.h
@@ -1,0 +1,4 @@
+
+extern "C" {
+    void class_touch_init();
+}

--- a/src/m5u/c_utils.cpp
+++ b/src/m5u/c_utils.cpp
@@ -1,0 +1,47 @@
+#include "c_utils.h"
+
+#include <M5Unified.h>
+
+#include "my_mrubydef.h"
+
+#ifdef USE_TEMPORAL_RANDOM_FUNCTION
+static void class_utils_randomseed(mrb_vm *vm, mrb_value *v, int argc) {
+  if (argc > 0) {
+    randomSeed(val_to_i(vm, v, GET_ARG(1), argc));
+  } else {
+    randomSeed(analogRead(0));
+  }
+  SET_TRUE_RETURN();
+}
+
+static void class_utils_random(mrb_vm *vm, mrb_value *v, int argc) {
+  if (argc > 1) {
+    SET_INT_RETURN(random(val_to_i(vm, v, GET_ARG(1), argc),
+                          val_to_i(vm, v, GET_ARG(2), argc)));
+  } else if (argc > 0) {
+    SET_INT_RETURN(random(val_to_i(vm, v, GET_ARG(1), argc)));
+  } else {
+    SET_INT_RETURN(random());
+  }
+}
+#endif  // USE_TEMPORAL_RANDOM_FUNCTION
+
+static void class_utils_millis(mrb_vm *vm, mrb_value *v, int argc) {
+  SET_INT_RETURN(xTaskGetTickCount());  // 後で直す。適当にも程がある
+}
+static void class_utils_delay(mrb_vm *vm, mrb_value *v, int argc) {
+  if (argc > 0)
+    vTaskDelay(
+        val_to_i(vm, v, GET_ARG(1), argc));  // 後で直す。適当にも程がある
+}
+
+void class_utils_init() {
+  mrbc_class *class_utils = mrbc_define_class(0, "Utils", mrbc_class_object);
+  mrbc_define_method(0, class_utils, "millis", class_utils_millis);
+  mrbc_define_method(0, class_utils, "delay", class_utils_delay);
+
+#ifdef USE_TEMPORAL_RANDOM_FUNCTION
+  mrbc_define_method(0, class_utils, "randomseed", class_utils_randomseed);
+  mrbc_define_method(0, class_utils, "random", class_utils_random);
+#endif  // USE_TEMPORAL_RANDOM_FUNCTION
+}

--- a/src/m5u/c_utils.h
+++ b/src/m5u/c_utils.h
@@ -1,0 +1,4 @@
+
+extern "C" {
+    void class_utils_init();
+}

--- a/src/m5u/drawing.cpp
+++ b/src/m5u/drawing.cpp
@@ -1,0 +1,226 @@
+//
+// Common drawing functions for M5GFX, M5Canvas
+//
+
+#include "drawing.h"
+
+#include <M5Unified.h>
+
+#include "my_mrubydef.h"
+
+void draw_set_text_size(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
+  if (argc > 0) {
+    int sz = val_to_i(vm, v, GET_ARG(1), argc);
+    dst->setTextSize(sz);
+    SET_TRUE_RETURN();
+  } else {
+    SET_FALSE_RETURN();
+  }
+}
+
+void draw_print(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
+  int r = 0;
+  for (int i = 1; i <= argc; i++) {
+    const char *str = val_to_s(vm, v, GET_ARG(i), argc);
+    r += dst->print(str);
+  }
+  SET_INT_RETURN(r);
+}
+
+void draw_puts(LovyanGFX *dst, mrb_vm *vm, mrb_value v[], int argc) {
+  int r = 0;
+  if (argc == 0) {
+    r += dst->println();
+  }
+  for (int i = 1; i <= argc; i++) {
+    const char *str = val_to_s(vm, v, GET_ARG(i), argc);
+    r += dst->println(str);
+  }
+  SET_INT_RETURN(r);
+}
+
+void draw_clear(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
+  int color = 0;
+  if (argc > 0) {
+    color = val_to_i(vm, v, GET_ARG(1), argc);
+  }
+
+  dst->clearDisplay(color);
+  dst->setCursor(0, 0);
+  SET_TRUE_RETURN();
+}
+
+void draw_set_text_color(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
+  if (argc > 1) {
+    dst->setTextColor(val_to_i(vm, v, GET_ARG(1), argc),
+                      val_to_i(vm, v, GET_ARG(2), argc));
+    SET_TRUE_RETURN();
+  } else if (argc > 0) {
+    dst->setTextColor(val_to_i(vm, v, GET_ARG(1), argc));
+    SET_TRUE_RETURN();
+  } else {
+    SET_FALSE_RETURN();
+  }
+}
+
+void draw_set_cursor(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
+  if (argc > 1) {
+    dst->setCursor(val_to_i(vm, v, GET_ARG(1), argc),
+                   val_to_i(vm, v, GET_ARG(2), argc));
+    SET_TRUE_RETURN();
+  } else {
+    SET_FALSE_RETURN();
+  }
+}
+
+void draw_get_cursor(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
+  mrbc_value ret = mrbc_array_new(vm, 2);
+  mrbc_value x = mrbc_fixnum_value(dst->getCursorX());
+  mrbc_value y = mrbc_fixnum_value(dst->getCursorY());
+  mrbc_array_set(&ret, 0, &x);
+  mrbc_array_set(&ret, 1, &y);
+  SET_RETURN(ret);
+}
+
+void draw_get_dimension(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
+  mrbc_value ret = mrbc_array_new(vm, 2);
+  mrbc_value w = mrbc_fixnum_value(dst->width());
+  mrbc_value h = mrbc_fixnum_value(dst->height());
+  mrbc_array_set(&ret, 0, &w);
+  mrbc_array_set(&ret, 1, &h);
+  SET_RETURN(ret);
+}
+
+//
+// for USE_DISPLAY_GRAPHICS
+//
+
+#ifdef USE_DISPLAY_GRAPHICS
+void draw_fill_rect(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
+  if (argc > 4) {
+    int x = val_to_i(vm, v, GET_ARG(1), argc);
+    int y = val_to_i(vm, v, GET_ARG(2), argc);
+    int w = val_to_i(vm, v, GET_ARG(3), argc);
+    int h = val_to_i(vm, v, GET_ARG(4), argc);
+    int color = val_to_i(vm, v, GET_ARG(5), argc);
+    dst->fillRect(x, y, w, h, color);
+    SET_TRUE_RETURN();
+  } else {
+    SET_FALSE_RETURN();
+  }
+}
+
+void draw_draw_rect(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
+  if (argc > 4) {
+    int x = val_to_i(vm, v, GET_ARG(1), argc);
+    int y = val_to_i(vm, v, GET_ARG(2), argc);
+    int w = val_to_i(vm, v, GET_ARG(3), argc);
+    int h = val_to_i(vm, v, GET_ARG(4), argc);
+    int color = val_to_i(vm, v, GET_ARG(5), argc);
+    dst->drawRect(x, y, w, h, color);
+    SET_TRUE_RETURN();
+  } else {
+    SET_FALSE_RETURN();
+  }
+}
+
+void draw_draw_line(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
+  if (argc > 4) {
+    int x1 = val_to_i(vm, v, GET_ARG(1), argc);
+    int y1 = val_to_i(vm, v, GET_ARG(2), argc);
+    int x2 = val_to_i(vm, v, GET_ARG(3), argc);
+    int y2 = val_to_i(vm, v, GET_ARG(4), argc);
+    int color = val_to_i(vm, v, GET_ARG(5), argc);
+    dst->drawLine(x1, y1, x2, y2, color);
+    SET_TRUE_RETURN();
+  } else {
+    SET_FALSE_RETURN();
+  }
+}
+
+void draw_flll_circle(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
+  if (argc > 3) {
+    int x = val_to_i(vm, v, GET_ARG(1), argc);
+    int y = val_to_i(vm, v, GET_ARG(2), argc);
+    int r = val_to_i(vm, v, GET_ARG(3), argc);
+    int color = val_to_i(vm, v, GET_ARG(4), argc);
+    dst->fillCircle(x, y, r, color);
+    SET_TRUE_RETURN();
+  } else {
+    SET_FALSE_RETURN();
+  }
+}
+
+void draw_draw_circle(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
+  if (argc > 3) {
+    int x = val_to_i(vm, v, GET_ARG(1), argc);
+    int y = val_to_i(vm, v, GET_ARG(2), argc);
+    int r = val_to_i(vm, v, GET_ARG(3), argc);
+    int color = val_to_i(vm, v, GET_ARG(4), argc);
+    dst->drawCircle(x, y, r, color);
+    SET_TRUE_RETURN();
+  } else {
+    SET_FALSE_RETURN();
+  }
+}
+
+#ifdef USE_FILE_FUNCTION
+
+static void draw_draw_pic_file(LovyanGFX *dst, draw_pic_type t, mrb_vm *vm,
+                               mrb_value *v, int argc) {
+  if (argc < 3) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "too few arguments");
+    return;
+  }
+  mrbc_value file = GET_ARG(1);
+  int r = mrbc_obj_is_kind_of(&file, class_file);
+  if (r == 0) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "not a file");
+    SET_FALSE_RETURN();
+    return;
+  }
+  File *f = *(File **)file.instance->data;
+  int x = val_to_i(vm, v, GET_ARG(2), argc);
+  int y = val_to_i(vm, v, GET_ARG(3), argc);
+
+  draw_draw_pic_stream(dst, t, f, x, y);
+
+  SET_TRUE_RETURN();
+}
+
+void draw_draw_bmp(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
+  draw_draw_pic_file(dst, bmp, vm, v, argc);
+}
+
+void draw_draw_jpg(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
+  draw_draw_pic_file(dst, jpg, vm, v, argc);
+}
+
+void draw_draw_png(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
+  draw_draw_pic_file(dst, png, vm, v, argc);
+}
+
+#endif  // USE_FILE_FUNCTION
+
+void draw_set_rotation(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
+  if (argc > 0) {
+    int rotation = val_to_i(vm, v, GET_ARG(1), argc);
+    dst->setRotation(rotation);
+    SET_TRUE_RETURN();
+  } else {
+    SET_FALSE_RETURN();
+  }
+}
+
+void draw_scroll(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
+  if (argc == 2) {
+    int dx = val_to_i(vm, v, GET_ARG(1), argc);
+    int dy = val_to_i(vm, v, GET_ARG(2), argc);
+    dst->scroll(dx, dy);
+  } else {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "dx and dy");
+    SET_FALSE_RETURN();
+  }
+}
+
+#endif  // USE_DISPLAY_GRAPHICS

--- a/src/m5u/drawing.h
+++ b/src/m5u/drawing.h
@@ -1,0 +1,22 @@
+
+
+#include <M5Unified.h>
+#include <mrubyc.h>
+
+typedef enum { bmp, jpg, png } draw_pic_type;
+
+void draw_set_text_size(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc);
+void draw_print(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc);
+void draw_puts(LovyanGFX *dst, mrb_vm *vm, mrb_value v[], int argc);
+void draw_clear(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc);
+void draw_set_text_color(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc);
+void draw_set_cursor(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc);
+void draw_get_cursor(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc);
+void draw_fill_rect(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc);
+void draw_draw_rect(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc);
+void draw_draw_line(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc);
+void draw_flll_circle(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc);
+void draw_draw_circle(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc);
+void draw_set_rotation(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc);
+void draw_get_dimension(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc);
+void draw_scroll(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc);

--- a/src/m5u/my_mrubydef.h
+++ b/src/m5u/my_mrubydef.h
@@ -1,0 +1,70 @@
+/****
+ *  my_mrubydef.h
+ *  configuration of my mruby/c library
+ *****/
+
+#ifndef _MY_MRUBYDEF_H_
+#define _MY_MRUBYDEF_H_
+
+#define USE_DISPLAY_GRAPHICS  // Display to support graphics functions
+#define USE_SPEAKER           // to support Speaker functions
+#define USE_CANVAS            // to support Canvas functions
+#define USE_TOUCH
+
+#include "c_m5.h"
+#include "mrubyc.h"
+
+inline const char *val_to_s(mrb_vm *vm, mrb_value *v, mrbc_value &recv,
+                            int regofs) {
+  const char *str;
+  if (recv.tt == MRBC_TT_STRING) {
+    str = (const char *)recv.string->data;
+  } else {
+    mrbc_value val = mrbc_send(vm, v, regofs, &recv, "to_s", 0);
+    str = (const char *)val.string->data;
+  }
+  return str;
+}
+inline int val_to_i(mrb_vm *vm, mrb_value *v, mrbc_value &recv, int regofs) {
+  int i;
+  if (recv.tt == MRBC_TT_FIXNUM) {
+    i = recv.i;
+  } else {
+    mrbc_value val = mrbc_send(vm, v, regofs, &recv, "to_i", 0);
+    i = val.i;
+  }
+  return i;
+}
+
+inline float val_to_f(mrb_vm *vm, mrb_value *v, mrbc_value &recv, int regofs) {
+  float f;
+  if (recv.tt == MRBC_TT_FLOAT) {
+    f = recv.d;
+  } else {
+    mrbc_value val = mrbc_send(vm, v, regofs, &recv, "to_f", 0);
+    f = val.d;
+  }
+  return f;
+}
+
+inline void put_null_data(mrb_value *v) {
+  *(uint8_t **)v->instance->data = nullptr;
+  // try in future // v->tt = MRBC_TT_EMPTY;
+}
+
+#define get_checked_data(cls, vm, v)                               \
+  *(cls **)(v->instance->data);                                    \
+  if (*(cls **)(v->instance->data) == nullptr) {                   \
+    mrbc_raise(vm, MRBC_CLASS(RuntimeError), "already destroyed"); \
+    return;                                                        \
+  }
+
+/*  This does not work
+inline uint8_t* get_checked_data(mrb_vm *vm, mrbc_value *v) {
+    if( *(uint8_t**)v->instance->data == nullptr){
+        mrbc_raise(vm, MRBC_CLASS(RuntimeError), "instance destroyed");
+    }
+    return v->instance->data;
+}
+*/
+#endif  // _MY_MRUBYDEF_H_

--- a/src/main.c
+++ b/src/main.c
@@ -27,6 +27,8 @@
 #include "rb/slot1.h"
 #include "rb/slot2.h"
 
+extern void init_c_m5u();  // for features in m5u directory
+
 #define MRBC_HEAP_MEMORY_SIZE (15 * 1024)
 #define MRUBYC_VM_MAIN_STACK_SIZE (50 * 1024)
 
@@ -66,6 +68,8 @@ void app_main() {
     api_led_define();    // LED.*
     api_input_define();  // Input.*
     api_blink_define();  // Blink.*
+
+    init_c_m5u();  // for features in m5u directory
 
     ////////////////////
     // Clear reload request flag


### PR DESCRIPTION
Import some code from my mrubyc-m5 project. 
This pull-request will support M5Unified functions in openblink-demo-m5.
Those are not the same as the original file because I removed troubled part like compile error.

Supported functions: (extracted)
M5.update
M5.board

Display.print/println/puts
Display.set_text_size/set_text_color/set_cursor/get_cursor/dimension
Display.clear/set_rotation
Display.color565 (to convert RGB to 16bit value)
DIsplay.fill_rect/draw_rect/fill_circle/draw_circle/draw_line/

BtnA,BtnB,BtnC as BtnClass
BtnClass#is_pressed?/was_pressed?

Speaker.tone/is_playing?/stop
Speaker.volume/volume=/get_volume/set_volume

and Touchpanel functions

Random number generation can be supported with USE_TEMPORAL_RANDOM_FUNCTION macro.
(Utils.randomseed and Utils.random)
