### PR TITLE
Clean up outdated code.

### DIFF
--- a/src/api/blink.c
+++ b/src/api/blink.c
@@ -11,9 +11,9 @@
  */
 #include "blink.h"
 
-#include "../../.pio/libdeps/m5stack-stamps3/mrubyc/src/mrubyc.h"
 #include "../lib/fn.h"
 #include "../main.h"
+#include "mrubyc.h"
 
 /**
  * @brief Forward declaration for the mruby/c method implementation

--- a/src/api/led.c
+++ b/src/api/led.c
@@ -14,9 +14,9 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include "../../.pio/libdeps/m5stack-stamps3/mrubyc/src/mrubyc.h"
 #include "../drv/led.h"
 #include "../lib/fn.h"
+#include "mrubyc.h"
 
 /**
  * @brief Forward declaration for the mruby/c method implementation

--- a/src/main.c
+++ b/src/main.c
@@ -16,7 +16,6 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#include "../.pio/libdeps/m5stack-stamps3/mrubyc/src/mrubyc.h"
 #include "api/blink.h"
 #include "api/input.h"
 #include "api/led.h"
@@ -24,6 +23,7 @@
 #include "app/init.h"
 #include "drv/ble_blink.h"
 #include "lib/fn.h"
+#include "mrubyc.h"
 #include "rb/slot1.h"
 #include "rb/slot2.h"
 #include "rb/slot_err.h"
@@ -31,10 +31,8 @@
 extern void init_c_m5u();  // for features in m5u directory
 
 #define MRBC_HEAP_MEMORY_SIZE (15 * 1024)
-#define MRUBYC_VM_MAIN_STACK_SIZE (50 * 1024)
 
 static bool request_mruby_reload = false;
-static bool block_run = false;
 
 static uint8_t memory_pool[MRBC_HEAP_MEMORY_SIZE] = {0};
 static uint8_t bytecode_slot2[BLINK_MAX_BYTECODE_SIZE] = {0};
@@ -54,7 +52,6 @@ void app_main() {
   }
 
   while (1) {
-    block_run = false;  // to be removed?
     mrbc_tcb *tcb[MAX_VM_COUNT] = {NULL};
 
     // mruby/c initialize
@@ -115,7 +112,6 @@ void app_main() {
  */
 fn_t app_mrubyc_vm_set_reload(void) {
   request_mruby_reload = true;
-  block_run = false;
   return kSuccess;
 }
 
@@ -125,13 +121,3 @@ fn_t app_mrubyc_vm_set_reload(void) {
  * @return true if reload is requested, false otherwise
  */
 bool app_mrubyc_vm_get_reload(void) { return request_mruby_reload; }
-
-/**
- * @brief Sets the mruby/c VM block run flag
- *
- * @return kSuccess always
- */
-fn_t app_mrubyc_vm_set_block_run(void) {
-  block_run = true;
-  return kSuccess;
-}

--- a/src/main.h
+++ b/src/main.h
@@ -29,11 +29,4 @@ fn_t app_mrubyc_vm_set_reload(void);
  */
 bool app_mrubyc_vm_get_reload(void);
 
-/**
- * @brief Sets the mruby/c VM block run flag
- *
- * @return kSuccess always
- */
-fn_t app_mrubyc_vm_set_block_run(void);
-
 #endif


### PR DESCRIPTION
This pull request includes several updates to the codebase, primarily focusing on simplifying header file inclusions and removing unused code. The most important changes are listed below:

Header file inclusions:

* [`src/api/blink.c`](diffhunk://#diff-5b562f3b6f236bd2fd2e4f76d11b70a49d0e250257d738249a6a5cfc24280a80L14-R16): Updated the inclusion path for `mrubyc.h` to a more direct path.
* [`src/api/led.c`](diffhunk://#diff-26dadb80c322412b882a2daa3f0c978a655b502c4192a48e07a748d71e3d6916L17-R19): Updated the inclusion path for `mrubyc.h` to a more direct path.
* [`src/main.c`](diffhunk://#diff-e0cf5b28d9b6b600f0af2bc78e8fd30ec675fd731a5da86f0c4283ffc0e40176L19-L37): Updated the inclusion path for `mrubyc.h` to a more direct path.

Code cleanup:

* [`src/main.c`](diffhunk://#diff-e0cf5b28d9b6b600f0af2bc78e8fd30ec675fd731a5da86f0c4283ffc0e40176L57): Removed the `block_run` variable and its associated code, as it was no longer in use. [[1]](diffhunk://#diff-e0cf5b28d9b6b600f0af2bc78e8fd30ec675fd731a5da86f0c4283ffc0e40176L57) [[2]](diffhunk://#diff-e0cf5b28d9b6b600f0af2bc78e8fd30ec675fd731a5da86f0c4283ffc0e40176L118) [[3]](diffhunk://#diff-e0cf5b28d9b6b600f0af2bc78e8fd30ec675fd731a5da86f0c4283ffc0e40176L128-L137)
* [`src/main.h`](diffhunk://#diff-910d89612d74e91ae70ed40289b3910b1c1a09b1f5a1bb0b15849f70760cbba2L32-L38): Removed the declaration of the `app_mrubyc_vm_set_block_run` function, as it was no longer in use.