### PR TITLE
Generate Unique DeviceName by MAC address

### DIFF
--- a/src/drv/ble.c
+++ b/src/drv/ble.c
@@ -40,7 +40,7 @@
 
 bool notify_state = false;
 uint16_t conn_handle;
-static char *device_name = "OpenBlink_ESP32";
+static char device_name[16] = "OpenBlink_ESP32";
 static int blehr_gap_event(struct ble_gap_event *event, void *arg);
 static uint8_t blehr_addr_type;
 struct ble_hs_cfg;

--- a/src/drv/ble.c
+++ b/src/drv/ble.c
@@ -34,10 +34,13 @@
 #include "nimble/nimble_port.h"
 #include "nimble/nimble_port_freertos.h"
 #include "services/gap/ble_svc_gap.h"
+/* MAC */
+#include "../lib/crc/crc.h"
+#include "esp_mac.h"
 
 bool notify_state = false;
 uint16_t conn_handle;
-static const char *device_name = "OpenBlink_ESP32";
+static char *device_name = "OpenBlink_ESP32";
 static int blehr_gap_event(struct ble_gap_event *event, void *arg);
 static uint8_t blehr_addr_type;
 struct ble_hs_cfg;
@@ -237,6 +240,14 @@ void blehr_host_task(void *param) {
  */
 void ble_init(void) {
   int rc;
+
+  // Generate DeviceName
+  uint8_t mac_base[6] = {0};
+  if (esp_efuse_mac_get_default(mac_base) == ESP_OK) {
+    // DeviceName = "OpenBlink_XXXX"
+    snprintf(device_name, 16, "OpenBlink_%04X",
+             crc16_reflect(0x9eb2U, 0xFFFFU, mac_base, sizeof(mac_base)));
+  }
 
   /* Initialize NVS — it is used to store PHY calibration data */
   esp_err_t ret = nvs_flash_init();


### PR DESCRIPTION
This pull request introduces changes to the BLE driver to dynamically generate the device name based on the ESP32's MAC address, improving device identification. Additionally, it updates the handling of the `device_name` variable to support this dynamic behavior.

### BLE device name generation:

* Added includes for `crc.h` and `esp_mac.h` to enable MAC address retrieval and CRC calculation for generating the device name. (`src/drv/ble.c`, [src/drv/ble.cR37-R43](diffhunk://#diff-8819480e80a641db37cc851925b09733f9c0ffe49223649205be7f6ea1cdf917R37-R43))
* Modified the `device_name` variable from `const char *` to `char *` to allow dynamic updates. (`src/drv/ble.c`, [src/drv/ble.cR37-R43](diffhunk://#diff-8819480e80a641db37cc851925b09733f9c0ffe49223649205be7f6ea1cdf917R37-R43))
* Introduced logic in `ble_init()` to generate a unique device name in the format `OpenBlink_XXXX`, where `XXXX` is derived from a CRC16 operation on the MAC address. (`src/drv/ble.c`, [src/drv/ble.cR244-R251](diffhunk://#diff-8819480e80a641db37cc851925b09733f9c0ffe49223649205be7f6ea1cdf917R244-R251))

### CRC polynomial
For the CRC polynomial, I referred to the information on the following URL:
https://users.ece.cmu.edu/~koopman/crc/